### PR TITLE
handle nulls properly

### DIFF
--- a/dynamoclasses/__init__.py
+++ b/dynamoclasses/__init__.py
@@ -11,7 +11,7 @@ TYPE_MAPPING = {
     bytes: {"key": "B", "fn": lambda x: str(x)},
     dict: {"key": "M", "fn": lambda x: x},
     bool: {"key": "BOOL", "fn": lambda x: x},
-    None: {"key": "NULL", "fn": lambda x: x},
+    type(None): {"key": "NULL", "fn": lambda x: True},
 }
 
 


### PR DESCRIPTION

at the moment passing a null results in key error in the type mapping lookup, it also serializes with the null value instead of as a boolean per the docs here.

https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_AttributeValue.html